### PR TITLE
Auto Link Deep Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ ceedling-*.gem
 .ruby-version
 
 /.idea
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ ceedling.sublime-workspace
 ceedling-*.gem
 .DS_Store
 .ruby-version
+
+/.idea

--- a/lib/ceedling/generator.rb
+++ b/lib/ceedling/generator.rb
@@ -19,7 +19,7 @@ class Generator
 
 
   def generate_shallow_includes_list(context, file)
-    @preprocessinator.preprocess_shallow_includes(file)
+    @preprocessinator.preprocess_includes(file)
   end
 
   def generate_preprocessed_file(context, file)

--- a/lib/ceedling/preprocessinator.rb
+++ b/lib/ceedling/preprocessinator.rb
@@ -29,7 +29,7 @@ class Preprocessinator
 
   def preprocess_shallow_includes(filepath)
     dependencies_rule = @preprocessinator_includes_handler.form_shallow_dependencies_rule(filepath)
-    includes          = @preprocessinator_includes_handler.extract_shallow_includes(dependencies_rule)
+    includes          = @preprocessinator_includes_handler.extract_includes(dependencies_rule)
 
     @preprocessinator_includes_handler.write_shallow_includes_list(
       @file_path_utils.form_preprocessed_includes_list_filepath(filepath), includes)

--- a/lib/ceedling/preprocessinator.rb
+++ b/lib/ceedling/preprocessinator.rb
@@ -8,7 +8,7 @@ class Preprocessinator
 
   def setup
     # fashion ourselves callbacks @preprocessinator_helper can use
-    @preprocess_includes_proc = Proc.new { |filepath| self.preprocess_shallow_includes(filepath) }
+    @preprocess_includes_proc = Proc.new { |filepath| self.preprocess_includes(filepath) }
     @preprocess_file_proc     = Proc.new { |filepath| self.preprocess_file(filepath) }
   end
 
@@ -27,9 +27,9 @@ class Preprocessinator
     return mocks_list
   end
 
-  def preprocess_shallow_includes(filepath)
+  def preprocess_includes(filepath)
     dependencies_rule = @preprocessinator_includes_handler.form_shallow_dependencies_rule(filepath)
-    includes          = @preprocessinator_includes_handler.extract_includes(dependencies_rule)
+    includes, _        = @preprocessinator_includes_handler.extract_includes(dependencies_rule)
 
     @preprocessinator_includes_handler.write_shallow_includes_list(
       @file_path_utils.form_preprocessed_includes_list_filepath(filepath), includes)

--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -56,7 +56,7 @@ class PreprocessinatorIncludesHandler
   #
   # === Return
   # _Array_ of _String_:: Array of the direct dependencies for the source file.
-  def extract_shallow_includes(make_rule, ignore_list = [])
+  def extract_includes(make_rule, ignore_list = [])
     # Extract the dependencies from the make rule
     hdr_ext = @configurator.extension_header
     dependencies = make_rule.split.find_all {|path| path.end_with?(hdr_ext) }.uniq
@@ -110,7 +110,7 @@ class PreprocessinatorIncludesHandler
         source_file = removed_header.delete_suffix(hdr_ext) + src_ext
         if File.exist?(source_file)
           other_make_rule = self.form_shallow_dependencies_rule(source_file)
-          other_deps = self.extract_shallow_includes(other_make_rule, removed_headers + real_headers + mock_headers)
+          other_deps = self.extract_includes(other_make_rule, removed_headers + real_headers + mock_headers)
           list += other_deps
         end
       end

--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -110,13 +110,14 @@ class PreprocessinatorIncludesHandler
         source_file = removed_header.delete_suffix(hdr_ext) + src_ext
         if File.exist?(source_file)
           other_make_rule = self.form_shallow_dependencies_rule(source_file)
-          other_deps = self.extract_includes(other_make_rule, removed_headers + real_headers + mock_headers)
+          other_deps, ignore_list = self.extract_includes(other_make_rule, ignore_list + removed_headers + real_headers + mock_headers)
           list += other_deps
+          ignore_list << removed_header
         end
       end
     end
 
-    list
+    return list, ignore_list
   end
 
   def write_shallow_includes_list(filepath, list)

--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -104,8 +104,7 @@ class PreprocessinatorIncludesHandler
     sdependencies.map! {|hdr| hdr.gsub('\\','/') }
     list += sdependencies
 
-    deep = @configurator.project_config_hash.has_key?(:project_auto_link_deep_dependencies) && @configurator.project_config_hash[:project_auto_link_deep_dependencies]
-    if deep
+    if @configurator.project_config_hash.has_key?(:project_auto_link_deep_dependencies) && @configurator.project_config_hash[:project_auto_link_deep_dependencies]
       # Find corresponding source files from removed header files (if they exist):
       removed_headers.find_all do |removed_header|
         source_file = removed_header.delete_suffix(hdr_ext) + src_ext

--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -56,11 +56,18 @@ class PreprocessinatorIncludesHandler
   #
   # === Return
   # _Array_ of _String_:: Array of the direct dependencies for the source file.
-  def extract_shallow_includes(make_rule)
+  def extract_shallow_includes(make_rule, ignore_list = [])
     # Extract the dependencies from the make rule
     hdr_ext = @configurator.extension_header
     dependencies = make_rule.split.find_all {|path| path.end_with?(hdr_ext) }.uniq
     dependencies.map! {|hdr| hdr.gsub('\\','/') }
+
+    if ignore_list.length > 0
+      # puts("XXX make_rule:\n************\n#{make_rule}\n***********")
+      # puts("XXX before [dependencies=#{dependencies}]\n[ignore_list=#{ignore_list}]")
+      dependencies -= ignore_list
+      # puts("XXX after [dependencies=#{dependencies}]")
+    end
 
     # Separate the real files form the annotated ones and remove the '@@@@'
     annotated_headers, real_headers = dependencies.partition {|hdr| hdr =~ /^@@@@/ }
@@ -69,6 +76,8 @@ class PreprocessinatorIncludesHandler
     # Find which of our annotated headers are "real" dependencies. This is
     # intended to weed out dependencies that have been removed due to build
     # options defined in the project yaml and/or in the headers themselves.
+    # puts("XXX before: [real_headers=#{real_headers}]")
+    removed_headers = []
     list = annotated_headers.find_all do |annotated_header|
       # find the index of the "real" include that matches the annotated one.
       idx = real_headers.find_index do |real_header|
@@ -78,14 +87,36 @@ class PreprocessinatorIncludesHandler
       # otherwise return nil. Since nil is falsy this has the effect of making
       # find_all return only the annotated headers for which a real include was
       # found/deleted
+      # puts("XXX [annotated_header=#{annotated_header}] : [idx=#{idx}]")
+      if idx != nil
+        removed_headers << real_headers[idx]
+      end
       idx ? real_headers.delete_at(idx) : nil
     end.compact
+    # puts("XXX after: [list=#{list}][removed_headers=#{removed_headers}]")
 
     # Extract direct dependencies that were also added
     src_ext = @configurator.extension_source
     sdependencies = make_rule.split.find_all {|path| path.end_with?(src_ext) }.uniq
     sdependencies.map! {|hdr| hdr.gsub('\\','/') }
     list += sdependencies
+
+    # XXX TOBY
+    deep = @configurator.project_config_hash.has_key?(:project_auto_link_deep_dependencies) && @configurator.project_config_hash[:project_auto_link_deep_dependencies]
+    if deep
+      # puts("TODO: IMPLEMENT DEEP LINK LOGIC...") # XXX
+      # Find corresponding source files from removed header files (if they exist):
+      removed_headers.find_all do |removed_header|
+        source_file = removed_header.delete_suffix(hdr_ext) + src_ext
+        # puts("XXX [source_file=#{source_file}]")
+        if File.exist?(source_file)
+          # puts("XXX Yes! It Exists!")
+          other_make_rule = self.form_shallow_dependencies_rule(source_file)
+          other_deps = self.extract_shallow_includes(other_make_rule, removed_headers + real_headers)
+          list += other_deps
+        end
+      end
+    end
 
     list
   end

--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -64,28 +64,15 @@ class PreprocessinatorIncludesHandler
 
     mock_headers = []
     if ignore_list.length > 0
-      # puts("XXX found ignore list. Processing start... {{{")
-      # puts("XXX make_rule:\n************\n#{make_rule}\n***********")
-      # puts("XXX before [dependencies=#{dependencies}]")
-      # puts("XXX before [ignore_list=#{ignore_list}]")
-
       mock_headers, processed_ignore_list = ignore_list.partition {|hdr| hdr =~ /^mock_/ }
-      # puts("XXX [mock_headers=#{mock_headers}]")
-      # puts("XXX before [processed_ignore_list=#{processed_ignore_list}]")
       stripped_mocked_list = mock_headers.map { |hdr| hdr.delete_prefix("mock_") }
       processed_ignore_list += stripped_mocked_list
-      # puts("XXX after [processed_ignore_list=#{processed_ignore_list}]")
-      
       dependencies -= processed_ignore_list
-      # puts("XXX after [dependencies=#{dependencies}]")
-      # puts("XXX now remove dependencies that are going to be mocked...")
       new_dependencies = dependencies.select do |d|
         bn = File.basename(d)
         !stripped_mocked_list.include?(bn)
       end
-      # puts("XXX after [new_dependencies=#{new_dependencies}]")
       dependencies = new_dependencies
-      # puts("XXX finished processing ignore list. }}}")
     end
 
     # Separate the real files form the annotated ones and remove the '@@@@'
@@ -95,7 +82,6 @@ class PreprocessinatorIncludesHandler
     # Find which of our annotated headers are "real" dependencies. This is
     # intended to weed out dependencies that have been removed due to build
     # options defined in the project yaml and/or in the headers themselves.
-    # puts("XXX before: [real_headers=#{real_headers}]")
     removed_headers = []
     list = annotated_headers.find_all do |annotated_header|
       # find the index of the "real" include that matches the annotated one.
@@ -111,7 +97,6 @@ class PreprocessinatorIncludesHandler
       end
       idx ? real_headers.delete_at(idx) : nil
     end.compact
-    # puts("XXX after: [list=#{list}][removed_headers=#{removed_headers}]")
 
     # Extract direct dependencies that were also added
     src_ext = @configurator.extension_source
@@ -124,14 +109,9 @@ class PreprocessinatorIncludesHandler
       # Find corresponding source files from removed header files (if they exist):
       removed_headers.find_all do |removed_header|
         source_file = removed_header.delete_suffix(hdr_ext) + src_ext
-        # puts("XXX [source_file=#{source_file}]")
         if File.exist?(source_file)
-          # puts("XXX source file exists: start recursive call: {{{")
           other_make_rule = self.form_shallow_dependencies_rule(source_file)
           other_deps = self.extract_shallow_includes(other_make_rule, removed_headers + real_headers + mock_headers)
-          # puts("XXX recursive call end.")
-          # puts("XXX [other_deps=#{other_deps}]")
-          # puts("XXX }}}")
           list += other_deps
         end
       end

--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -62,11 +62,30 @@ class PreprocessinatorIncludesHandler
     dependencies = make_rule.split.find_all {|path| path.end_with?(hdr_ext) }.uniq
     dependencies.map! {|hdr| hdr.gsub('\\','/') }
 
+    mock_headers = []
     if ignore_list.length > 0
+      # puts("XXX found ignore list. Processing start... {{{")
       # puts("XXX make_rule:\n************\n#{make_rule}\n***********")
-      # puts("XXX before [dependencies=#{dependencies}]\n[ignore_list=#{ignore_list}]")
-      dependencies -= ignore_list
+      # puts("XXX before [dependencies=#{dependencies}]")
+      # puts("XXX before [ignore_list=#{ignore_list}]")
+
+      mock_headers, processed_ignore_list = ignore_list.partition {|hdr| hdr =~ /^mock_/ }
+      # puts("XXX [mock_headers=#{mock_headers}]")
+      # puts("XXX before [processed_ignore_list=#{processed_ignore_list}]")
+      stripped_mocked_list = mock_headers.map { |hdr| hdr.delete_prefix("mock_") }
+      processed_ignore_list += stripped_mocked_list
+      # puts("XXX after [processed_ignore_list=#{processed_ignore_list}]")
+      
+      dependencies -= processed_ignore_list
       # puts("XXX after [dependencies=#{dependencies}]")
+      # puts("XXX now remove dependencies that are going to be mocked...")
+      new_dependencies = dependencies.select do |d|
+        bn = File.basename(d)
+        !stripped_mocked_list.include?(bn)
+      end
+      # puts("XXX after [new_dependencies=#{new_dependencies}]")
+      dependencies = new_dependencies
+      # puts("XXX finished processing ignore list. }}}")
     end
 
     # Separate the real files form the annotated ones and remove the '@@@@'
@@ -87,7 +106,6 @@ class PreprocessinatorIncludesHandler
       # otherwise return nil. Since nil is falsy this has the effect of making
       # find_all return only the annotated headers for which a real include was
       # found/deleted
-      # puts("XXX [annotated_header=#{annotated_header}] : [idx=#{idx}]")
       if idx != nil
         removed_headers << real_headers[idx]
       end
@@ -101,18 +119,19 @@ class PreprocessinatorIncludesHandler
     sdependencies.map! {|hdr| hdr.gsub('\\','/') }
     list += sdependencies
 
-    # XXX TOBY
     deep = @configurator.project_config_hash.has_key?(:project_auto_link_deep_dependencies) && @configurator.project_config_hash[:project_auto_link_deep_dependencies]
     if deep
-      # puts("TODO: IMPLEMENT DEEP LINK LOGIC...") # XXX
       # Find corresponding source files from removed header files (if they exist):
       removed_headers.find_all do |removed_header|
         source_file = removed_header.delete_suffix(hdr_ext) + src_ext
         # puts("XXX [source_file=#{source_file}]")
         if File.exist?(source_file)
-          # puts("XXX Yes! It Exists!")
+          # puts("XXX source file exists: start recursive call: {{{")
           other_make_rule = self.form_shallow_dependencies_rule(source_file)
-          other_deps = self.extract_shallow_includes(other_make_rule, removed_headers + real_headers)
+          other_deps = self.extract_shallow_includes(other_make_rule, removed_headers + real_headers + mock_headers)
+          # puts("XXX recursive call end.")
+          # puts("XXX [other_deps=#{other_deps}]")
+          # puts("XXX }}}")
           list += other_deps
         end
       end

--- a/spec/preprocessinator_includes_handler_spec.rb
+++ b/spec/preprocessinator_includes_handler_spec.rb
@@ -179,6 +179,28 @@ describe PreprocessinatorIncludesHandler do
   end
 
   context 'invoke_shallow_includes_list' do
+    it 'should ignore files in ignore_list param' do
+      # create test state/variables
+      # mocks/stubs/expected calls
+      expect(@configurator).to receive(:extension_header).and_return('.h')
+      expect(@configurator).to receive(:extension_source).and_return('.c')
+      expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
+      # execute method
+      results = subject.extract_shallow_includes(\
+        '_test_DUMMY.o: '\
+          'source\some_header1.h '\
+          'source\some_header2.h '\
+          '@@@@some_header1.h '\
+          '@@@@some_header2.h '\
+          '@@@@some_header3.h '\
+          'source\some_header3.h'\
+      , ["source/some_header1.h", "mock_some_header2.h"])
+      # validate results
+      expect(results).to eq ['some_header3.h']
+    end
+  end
+
+  context 'invoke_shallow_includes_list' do
     it 'should invoke the rake task which will build included files' do
       # create test state/variables
       # mocks/stubs/expected calls

--- a/spec/preprocessinator_includes_handler_spec.rb
+++ b/spec/preprocessinator_includes_handler_spec.rb
@@ -69,7 +69,7 @@ describe PreprocessinatorIncludesHandler do
       expect(@configurator).to receive(:extension_source).and_return('.c')
       expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
-      results = subject.extract_includes(%q{
+      results, _ = subject.extract_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
           source/some_header1.h \
           source/some_lib/some_header2.h \
@@ -92,7 +92,7 @@ describe PreprocessinatorIncludesHandler do
       expect(@configurator).to receive(:extension_source).and_return('.c')
       expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
-      results = subject.extract_includes(%q{
+      results, _ = subject.extract_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
           source/some_header1.h \
           source/some_lib/some_header2.h \
@@ -115,7 +115,7 @@ describe PreprocessinatorIncludesHandler do
       expect(@configurator).to receive(:extension_source).and_return('.c')
       expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
-      results = subject.extract_includes(%q{
+      results, _ = subject.extract_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
           source\some_header1.h \
           source\some_lib\some_header2.h \
@@ -141,7 +141,7 @@ describe PreprocessinatorIncludesHandler do
       expect(@configurator).to receive(:extension_source).and_return('.c')
       expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
-      results = subject.extract_includes(%q{
+      results, _ = subject.extract_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
           source/some_header1.h \
           @@@@some_header1.h \
@@ -158,7 +158,7 @@ describe PreprocessinatorIncludesHandler do
       expect(@configurator).to receive(:extension_source).and_return('.c')
       expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
-      results = subject.extract_includes(%q{
+      results, _ = subject.extract_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
           source\some_header1.h \
           source\some_lib\some_header2.h \
@@ -186,7 +186,7 @@ describe PreprocessinatorIncludesHandler do
       expect(@configurator).to receive(:extension_source).and_return('.c')
       expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
-      results = subject.extract_includes(\
+      results, _ = subject.extract_includes(\
         '_test_DUMMY.o: '\
           'source\some_header1.h '\
           'source\some_header2.h '\
@@ -212,7 +212,7 @@ describe PreprocessinatorIncludesHandler do
       allow(subject).to receive(:form_shallow_dependencies_rule).with("source/a.c").and_return("dummy.o: source/b.h @@@@b.h")
 
       # execute method
-      results = subject.extract_includes(\
+      results, _ = subject.extract_includes(\
         '_test_a.o: '\
           'source\a.h '\
           '@@@@a.h')

--- a/spec/preprocessinator_includes_handler_spec.rb
+++ b/spec/preprocessinator_includes_handler_spec.rb
@@ -67,6 +67,7 @@ describe PreprocessinatorIncludesHandler do
       # mocks/stubs/expected calls
       expect(@configurator).to receive(:extension_header).and_return('.h')
       expect(@configurator).to receive(:extension_source).and_return('.c')
+      expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
       results = subject.extract_shallow_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
@@ -89,6 +90,7 @@ describe PreprocessinatorIncludesHandler do
       # mocks/stubs/expected calls
       expect(@configurator).to receive(:extension_header).and_return('.h')
       expect(@configurator).to receive(:extension_source).and_return('.c')
+      expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
       results = subject.extract_shallow_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
@@ -111,6 +113,7 @@ describe PreprocessinatorIncludesHandler do
       # mocks/stubs/expected calls
       expect(@configurator).to receive(:extension_header).and_return('.h')
       expect(@configurator).to receive(:extension_source).and_return('.c')
+      expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
       results = subject.extract_shallow_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
@@ -136,6 +139,7 @@ describe PreprocessinatorIncludesHandler do
       # mocks/stubs/expected calls
       expect(@configurator).to receive(:extension_header).and_return('.h')
       expect(@configurator).to receive(:extension_source).and_return('.c')
+      expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
       results = subject.extract_shallow_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
@@ -152,6 +156,7 @@ describe PreprocessinatorIncludesHandler do
       # mocks/stubs/expected calls
       expect(@configurator).to receive(:extension_header).and_return('.h')
       expect(@configurator).to receive(:extension_source).and_return('.c')
+      expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
       results = subject.extract_shallow_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \

--- a/spec/preprocessinator_includes_handler_spec.rb
+++ b/spec/preprocessinator_includes_handler_spec.rb
@@ -201,6 +201,28 @@ describe PreprocessinatorIncludesHandler do
   end
 
   context 'invoke_shallow_includes_list' do
+    it 'should do a recursive call when deep dependency linking is enabled' do
+      # create test state/variables
+      # mocks/stubs/expected calls
+      expect(@configurator).to receive(:extension_header).and_return('.h').twice
+      expect(@configurator).to receive(:extension_source).and_return('.c').twice
+      expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => true }).exactly(4).times
+      allow(File).to receive(:exist?).with("source/a.c").and_return(true)
+      allow(File).to receive(:exist?).with("source/b.c").and_return(false)
+      allow(subject).to receive(:form_shallow_dependencies_rule).with("source/a.c").and_return("dummy.o: source/b.h @@@@b.h")
+
+      # execute method
+      results = subject.extract_shallow_includes(\
+        '_test_a.o: '\
+          'source\a.h '\
+          '@@@@a.h')
+
+      # validate results
+      expect(results).to eq ['a.h', 'b.h']
+    end
+  end
+
+  context 'invoke_shallow_includes_list' do
     it 'should invoke the rake task which will build included files' do
       # create test state/variables
       # mocks/stubs/expected calls

--- a/spec/preprocessinator_includes_handler_spec.rb
+++ b/spec/preprocessinator_includes_handler_spec.rb
@@ -61,7 +61,7 @@ describe PreprocessinatorIncludesHandler do
     end
   end
 
-  context 'extract_shallow_includes' do
+  context 'extract_includes' do
     it 'should return the list of direct dependencies for the given test file' do
       # create test state/variables
       # mocks/stubs/expected calls
@@ -69,7 +69,7 @@ describe PreprocessinatorIncludesHandler do
       expect(@configurator).to receive(:extension_source).and_return('.c')
       expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
-      results = subject.extract_shallow_includes(%q{
+      results = subject.extract_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
           source/some_header1.h \
           source/some_lib/some_header2.h \
@@ -92,7 +92,7 @@ describe PreprocessinatorIncludesHandler do
       expect(@configurator).to receive(:extension_source).and_return('.c')
       expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
-      results = subject.extract_shallow_includes(%q{
+      results = subject.extract_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
           source/some_header1.h \
           source/some_lib/some_header2.h \
@@ -115,7 +115,7 @@ describe PreprocessinatorIncludesHandler do
       expect(@configurator).to receive(:extension_source).and_return('.c')
       expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
-      results = subject.extract_shallow_includes(%q{
+      results = subject.extract_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
           source\some_header1.h \
           source\some_lib\some_header2.h \
@@ -141,7 +141,7 @@ describe PreprocessinatorIncludesHandler do
       expect(@configurator).to receive(:extension_source).and_return('.c')
       expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
-      results = subject.extract_shallow_includes(%q{
+      results = subject.extract_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
           source/some_header1.h \
           @@@@some_header1.h \
@@ -158,7 +158,7 @@ describe PreprocessinatorIncludesHandler do
       expect(@configurator).to receive(:extension_source).and_return('.c')
       expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
-      results = subject.extract_shallow_includes(%q{
+      results = subject.extract_includes(%q{
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
           source\some_header1.h \
           source\some_lib\some_header2.h \
@@ -186,7 +186,7 @@ describe PreprocessinatorIncludesHandler do
       expect(@configurator).to receive(:extension_source).and_return('.c')
       expect(@configurator).to receive(:project_config_hash).and_return({ :project_auto_link_deep_dependencies => false }).twice
       # execute method
-      results = subject.extract_shallow_includes(\
+      results = subject.extract_includes(\
         '_test_DUMMY.o: '\
           'source\some_header1.h '\
           'source\some_header2.h '\
@@ -212,7 +212,7 @@ describe PreprocessinatorIncludesHandler do
       allow(subject).to receive(:form_shallow_dependencies_rule).with("source/a.c").and_return("dummy.o: source/b.h @@@@b.h")
 
       # execute method
-      results = subject.extract_shallow_includes(\
+      results = subject.extract_includes(\
         '_test_a.o: '\
           'source\a.h '\
           '@@@@a.h')


### PR DESCRIPTION
### Problem

Consider following project structure:
```
/src
|--- a.c
|--- a.h
|--- b.c
|--- b.h

/test
|--- test_a.c
```
where `a.c` includes `b.h`.

Current Ceedling philosophy is to be explicit about all dependencies which means that in this case `test_a.c` has to explicitly include `a.h` as well as it's "nested" ("deep") dependency `b.h`. [More on this topic](https://github.com/ThrowTheSwitch/Ceedling/issues/142). 

### Objective

Modify Ceedling to be able to discover and auto-link deep dependencies.
Implement new Ceedling `:project:`-level flag to enable/disable this feature.

### Aceptance Criteria

1. `test_a.c` test suite passes as is
2. If `#include mock_b.h` is added to the `test_a.c`, then `b.h` is mocked instead of auto-included
3. Deep dependency discovery stops at the system library level
4. Deep dependency discovery supports 3rd party libraries (see `test_my_table.c`)

### Sub-tasks

- [x] 1. Setup this project with Ceedling
- [x] 1.1.  Use `--local` flag to get all sources copied into the current project folder
- [x] 1.2. Check out https://github.com/zaleos/Ceedling
- [x] 1.3. Replace local version of the project with symlinks to local https://github.com/zaleos/Ceedling
- [x] 2. Implement logic
- [x] 2.1. Include deep linked files
- [x] 2.2. Skip mock headers
- [x] 3. Testing
- [x] 3.1. Fix broken tests
- [x] 3.2. Add tests for new behaviour
- [x] 3.2.1. Test ignore_list param (with and without mock_* headers)
- [x] 3.2.2. Test deep link recursive call
